### PR TITLE
Replace deprecated build tooling with Node APIs and document blocked audit

### DIFF
--- a/SECURITY_REPORT.md
+++ b/SECURITY_REPORT.md
@@ -1,0 +1,27 @@
+# Dependency and Security Audit (Offline Environment)
+
+## Summary
+- Performed dependency cleanup by replacing the deprecated `ncp` and standalone `rimraf` dev dependencies with native Node.js file utilities.
+- Attempted to run automated security and update checks (`npm audit`, `yarn npm audit`, `npm outdated`, `npm-check-updates`) but all requests were blocked by the execution environment's proxy (HTTP 403).
+- Added small utility scripts to keep the existing build workflows functional without the removed packages.
+
+## Commands Executed
+| Command | Purpose | Result |
+| --- | --- | --- |
+| `npm audit --production` | Check production dependency vulnerabilities | Failed – npm requires a lockfile and remote registry access. |
+| `yarn npm audit --severity high` | Yarn-based audit focusing on high severity issues | Failed – HTTP 403 response from proxy. |
+| `npm outdated` | Inspect available package updates | Failed – HTTP 403 response from proxy. |
+| `npx npm-check-updates` | Discover latest versions and detect breaking upgrades | Failed – HTTP 403 response from proxy. |
+| `yarn install` | Refresh `node_modules` after dependency edits | Failed – HTTP 403 response from proxy. |
+
+Refer to the terminal output in the development session for the exact error traces.
+
+## Manual Dependency Notes
+- `@marp-team/marp-cli@^2.2.1` remains the sole dev dependency. Updating it further requires online access to confirm the latest stable release and review changelog for breaking changes.
+- Removed `ncp` (deprecated) and `rimraf` (superseded by `fs.cpSync` and `fs.rmSync`) from direct dependencies. Runtime copies bundled via transitive dependencies (for example, through `puppeteer-core`) remain untouched.
+
+## Recommended Next Steps (with Network Access)
+1. Restore registry connectivity or supply a mirror that accepts audit/update requests.
+2. Rerun the audit and update commands listed above.
+3. Inspect the changelog for `@marp-team/marp-cli` before applying any major version upgrade to avoid breaking CLI flags or output formats.
+4. Re-run the build scripts (`yarn clean`, `yarn deck`, `yarn pdf`) to ensure the new native file utilities behave as expected across platforms.

--- a/package.json
+++ b/package.json
@@ -12,16 +12,14 @@
   "license": "MIT",
   "scripts": {
     "dev": "marp -s content --watch",
-    "deck": "marp --no-stdin content/index.md -o public/index.html && ncp content/assets public/assets",
+    "deck": "marp --no-stdin content/index.md -o public/index.html && node scripts/copy-assets.mjs",
     "pdf": "marp --pdf --allow-local-files content/index.md -o public/converted.pdf",
-    "clean": "rimraf public",
-    "build": "rimraf public && yarn deck",
-    "vercel-build": "npm i puppeteer --no-save && MARP_USER=root CHROME_PATH=$(node -e \"console.log(require('puppeteer').executablePath())\") yarn build"
+    "copy-assets": "node scripts/copy-assets.mjs",
+    "clean": "node scripts/clean.mjs",
+    "build": "node scripts/clean.mjs && marp --no-stdin content/index.md -o public/index.html && node scripts/copy-assets.mjs",
+    "vercel-build": "npm i puppeteer --no-save && MARP_USER=root CHROME_PATH=$(node -e \"console.log(require('puppeteer').executablePath())\") npm run build"
   },
-  "dependencies": {},
   "devDependencies": {
-    "@marp-team/marp-cli": "^2.2.1",
-    "ncp": "^2.0.0",
-    "rimraf": "^3.0.2"
+    "@marp-team/marp-cli": "^2.2.1"
   }
 }

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+import { rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const target = resolve('public');
+
+try {
+  rmSync(target, { recursive: true, force: true });
+} catch (error) {
+  console.error(`Failed to remove ${target}:`, error);
+  process.exitCode = 1;
+}

--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import { cpSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const source = resolve('content/assets');
+const destination = resolve('public/assets');
+
+if (!existsSync(source)) {
+  console.warn(`Skipping asset copy because the source directory does not exist: ${source}`);
+  process.exit(0);
+}
+
+mkdirSync(dirname(destination), { recursive: true });
+
+try {
+  cpSync(source, destination, { recursive: true, force: true });
+} catch (error) {
+  console.error(`Failed to copy assets from ${source} to ${destination}:`, error);
+  process.exitCode = 1;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -750,11 +750,6 @@ nanoid@^3.3.6:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
-ncp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
-  integrity sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==
-
 negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"


### PR DESCRIPTION
## Summary
- swap the old rimraf/ncp build helpers for Node.js file utilities and wire them into the package scripts
- add a SECURITY_REPORT that records the blocked security/update checks and follow-up steps once registry access is restored

## Testing
- npm run clean
- npm run deck

------
https://chatgpt.com/codex/tasks/task_b_68eeccacd46c83248032ccf5e33feb74